### PR TITLE
build(docker): add mongo to docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!poetry*
+!pyproject.toml
+!.env
+!ezar

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .venv
 .env
 .vscode
+mongo_data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,18 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    links:
+      - mongodb
+    environment:
+      MONGO_URI: mongodb://ezar:WhatAShame@mongodb:27017/eZaR
+  mongodb:
+    image: mongo:6.0
+    environment:
+      MONGO_INITDB_DATABASE_USERNAME: ezar
+      MONGO_INITDB_DATABASE_PASSWORD: WhatAShame
+      MONGO_INITDB_DATABASE: eZaR
+    expose:
+      - 27017
+    volumes:
+      - ./mongo_data:/data/db
+      - ./mongo_init.js:/docker-entrypoint-initdb.d/init.js:ro

--- a/mongo_init.js
+++ b/mongo_init.js
@@ -1,0 +1,10 @@
+db.createUser({
+  user: "ezar",
+  pwd: "WhatAShame",
+  roles: [
+    {
+      role: "readWrite",
+      db: "eZaR",
+    },
+  ],
+});


### PR DESCRIPTION
Add MongoDB to `docker-compose.yml`, along with a `.dockerignore` to only pass relevant files to the Docker daemon.
